### PR TITLE
defend against defining records that may backtrack catastrophically

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,10 +333,12 @@ Some texts may use whitespace inconsistently. To ignore whitespace at the start 
 For example, this extractor:
 
 ```ruby
+strip :left
+
 value :this, /\w+/
 value :that, /\w+/
 
-record(strip: :left) do
+record do
   /
   This: #{this}
   That: #{that}

--- a/lib/text_extractor/record.rb
+++ b/lib/text_extractor/record.rb
@@ -42,7 +42,11 @@ class TextExtractor
     def build_regexp(regexp, directives, strip)
       stripped = strip_regexp(regexp, strip)
       expanded = expand_regexp(stripped, directives)
-      ignore_regexp(expanded, strip)
+      final = ignore_regexp(expanded, strip)
+
+      raise EmptyRecordError, 'Empty record detected' if final =~ ''
+
+      final
     end
 
     def strip_regexp(regexp, strip)
@@ -178,4 +182,6 @@ class TextExtractor
       end
     end # class FactoryAnalyzer
   end # class Record
+
+  class EmptyRecordError < StandardError; end
 end # class TextExtractor

--- a/test/text_extractor/test_empty_record.rb
+++ b/test/text_extractor/test_empty_record.rb
@@ -1,0 +1,53 @@
+require_relative '../test_helper'
+require 'text_extractor'
+
+# checks that records that match an empty string will raise an exception when
+# they are first defined
+class TestEmptyRecord < Minitest::Test
+  def test_totally_empty_record
+    line = nil
+
+    error = assert_raises(TextExtractor::EmptyRecordError) do
+      TextExtractor.new do
+        line = __LINE__
+        record do
+          //
+        end
+      end
+    end
+
+    trace = error.backtrace.inspect
+    assert_match(/#{__FILE__}:#{line + 1}:in/, trace)
+  end
+
+  def test_single_newline_record
+    assert_raises(TextExtractor::EmptyRecordError) do
+      TextExtractor.new do
+        record do
+          /
+          /
+        end
+      end
+    end
+  end
+
+  def test_double_newline_record
+    TextExtractor.new do
+      record do
+        /
+
+        /
+      end
+    end
+  end
+
+  def test_match_any_record
+    assert_raises(TextExtractor::EmptyRecordError) do
+      TextExtractor.new do
+        record do
+          /.*/
+        end
+      end
+    end
+  end
+end

--- a/test/text_extractor/test_strip.rb
+++ b/test/text_extractor/test_strip.rb
@@ -20,14 +20,20 @@ class TestTextExtractorStrip < Minitest::Test
   ].freeze
 
   EXTRACTOR = TextExtractor.new do
+    strip :left
+
     value :this, /\w+/
     value :that, /\w+/
 
-    record(strip: :left) do
+    record do
       /
       This: #{this}
       That: #{that}
       /
     end
+  end
+
+  def test_strip_left
+    assert_equal OUTPUT, EXTRACTOR.scan(INPUT)
   end
 end


### PR DESCRIPTION
# remove strip record param

The `strip` param to a record definition quietly adds a repeating section to each line of the provided regex to consume extra whitespace. Adjacent repeats other are a common cause of regex explosion, so hidden repeats are especially risky. As a substitute (an imperfect one), we add a `strip` instance method to remove whitespace from the input text.

This is a breaking change for any extractor currently using the `strip` param. Anyone using this param should remove it and update their regexes as needed. For some extractors, it may be enough to switch to using the `strip` instance method as described in the updated README.

# raise an exception if a record would match an empty string

I couldn't think of any reason to allow this, and it is rough on my CPU to test such a record.